### PR TITLE
fix splash screen

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,7 @@
         "icon": "./src/assets/images/logo.png",
         "scheme": "impactmarket",
         "splash": {
-            "image": "./src/assets/images/splash.png",
+            "image": "./src/assets/images/splash@3x.png",
             "resizeMode": "cover",
             "backgroundColor": "#2362FB"
         },


### PR DESCRIPTION
"By default splash.image would be used as the xxxdpi resource"
https://docs.expo.io/guides/splash-screens/?redirected#splash-screen-api-limitations-on-android

Simply added a bigger resolution image. SDK42 allows different resolutions https://docs.expo.io/versions/latest/config/app/#splash-2