### PR TITLE
Fix/ipct1 340/currency search buggy behavior

### DIFF
--- a/src/views/createCommunity/index.tsx
+++ b/src/views/createCommunity/index.tsx
@@ -945,12 +945,12 @@ function CreateCommunityScreen() {
             const currencyResult: string[] = [];
             for (const [key, value] of Object.entries(currencies)) {
                 if (
-                    value.name.toLowerCase().indexOf(e.toLowerCase()) !== -1 ||
-                    value.symbol.toLowerCase().indexOf(e.toLowerCase()) !==
-                        -1 ||
-                    value.symbol_native
-                        .toLowerCase()
-                        .indexOf(e.toLowerCase()) !== -1
+                    value.name.toLowerCase().indexOf(e.toLowerCase()) !== -1
+                    // value.symbol.toLowerCase().indexOf(e.toLowerCase()) !==
+                    //     -1 ||
+                    // value.symbol_native
+                    //     .toLowerCase()
+                    //     .indexOf(e.toLowerCase()) !== -1
                 ) {
                     currencyResult.push(key);
                 }

--- a/src/views/createCommunity/index.tsx
+++ b/src/views/createCommunity/index.tsx
@@ -14,6 +14,7 @@ import WarningRedTriangle from 'components/svg/WarningRedTriangle';
 import BackSvg from 'components/svg/header/BackSvg';
 import Clipboard from 'expo-clipboard';
 import * as ImagePicker from 'expo-image-picker';
+import { ImageInfo } from 'expo-image-picker/build/ImagePicker.types';
 import * as Location from 'expo-location';
 import { Screens, celoNetwork } from 'helpers/constants';
 import {
@@ -83,7 +84,6 @@ import config from '../../../config';
 import CommunityContractABI from '../../contracts/CommunityABI.json';
 import CommunityBytecode from '../../contracts/CommunityBytecode.json';
 import SubmitCommunity from '../../navigator/header/SubmitCommunity';
-import { ImageInfo } from 'expo-image-picker/build/ImagePicker.types';
 
 const countries: {
     [key: string]: {
@@ -945,9 +945,12 @@ function CreateCommunityScreen() {
             const currencyResult: string[] = [];
             for (const [key, value] of Object.entries(currencies)) {
                 if (
-                    value.name.indexOf(searchCurrency) !== -1 ||
-                    value.symbol.indexOf(searchCurrency) !== -1 ||
-                    value.symbol_native.indexOf(searchCurrency) !== -1
+                    value.name.toLowerCase().indexOf(e.toLowerCase()) !== -1 ||
+                    value.symbol.toLowerCase().indexOf(e.toLowerCase()) !==
+                        -1 ||
+                    value.symbol_native
+                        .toLowerCase()
+                        .indexOf(e.toLowerCase()) !== -1
                 ) {
                     currencyResult.push(key);
                 }
@@ -1063,8 +1066,8 @@ function CreateCommunityScreen() {
                     <WebView
                         originWhitelist={['*']}
                         source={{ uri: webviewURL }}
-                        javaScriptEnabled={true}
-                        domStorageEnabled={true}
+                        javaScriptEnabled
+                        domStorageEnabled
                         onLoadStart={() => setVisible(true)}
                         onLoad={() => setVisible(false)}
                     />

--- a/src/views/profile/index.tsx
+++ b/src/views/profile/index.tsx
@@ -285,10 +285,10 @@ function ProfileScreen() {
         const currencyResult: string[] = [];
         for (const [key, value] of Object.entries(currencies)) {
             if (
-                value.name.toLowerCase().indexOf(e.toLowerCase()) !== -1 ||
-                value.symbol.toLowerCase().indexOf(e.toLowerCase()) !== -1 ||
-                value.symbol_native.toLowerCase().indexOf(e.toLowerCase()) !==
-                    -1
+                value.name.toLowerCase().indexOf(e.toLowerCase()) !== -1
+                // value.symbol.toLowerCase().indexOf(e.toLowerCase()) !== -1 ||
+                // value.symbol_native.toLowerCase().indexOf(e.toLowerCase()) !==
+                //     -1
             ) {
                 currencyResult.push(key);
             }

--- a/src/views/profile/index.tsx
+++ b/src/views/profile/index.tsx
@@ -18,6 +18,7 @@ import BackSvg from 'components/svg/header/BackSvg';
 import Constants from 'expo-constants';
 import * as Device from 'expo-device';
 import * as ImagePicker from 'expo-image-picker';
+import { ImageInfo } from 'expo-image-picker/build/ImagePicker.types';
 import * as Linking from 'expo-linking';
 import { imageTargets } from 'helpers/constants';
 // Helpers
@@ -45,7 +46,6 @@ import {
 } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { Modalize } from 'react-native-modalize';
-
 import {
     Portal,
     Button as RNButton,
@@ -63,7 +63,6 @@ import Api from 'services/api';
 import CacheStore from 'services/cacheStore';
 // Styles
 import { ipctColors } from 'styles/index';
-import { ImageInfo } from 'expo-image-picker/build/ImagePicker.types';
 
 // Constants
 const currencies: {
@@ -279,28 +278,21 @@ function ProfileScreen() {
 
     const handleSearchCurrency = (e: string) => {
         setSearchCurrency(e);
+
+        if (searchCurrency.length <= 0) {
+            return;
+        }
         const currencyResult: string[] = [];
         for (const [key, value] of Object.entries(currencies)) {
             if (
-                key.toLowerCase().indexOf(searchCurrency.toLowerCase()) !==
-                    -1 ||
-                value.name
-                    .toLowerCase()
-                    .indexOf(searchCurrency.toLowerCase()) !== -1 ||
-                value.symbol
-                    .toLowerCase()
-                    .indexOf(searchCurrency.toLowerCase()) !== -1 ||
-                value.symbol_native
-                    .toLowerCase()
-                    .indexOf(searchCurrency.toLowerCase()) !== -1
+                value.name.toLowerCase().indexOf(e.toLowerCase()) !== -1 ||
+                value.symbol.toLowerCase().indexOf(e.toLowerCase()) !== -1 ||
+                value.symbol_native.toLowerCase().indexOf(e.toLowerCase()) !==
+                    -1
             ) {
                 currencyResult.push(key);
             }
         }
-        //
-        // if (currencyResult.length > 15) {
-        //     setTooManyResultForQuery(true);
-        // } else {
         setSearchCurrencyResult(currencyResult);
         setShowingResults(true);
         // }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "jsx": "react",
         "baseUrl": "src",
         "paths": {
             "assets": ["./src/assets"],


### PR DESCRIPTION
This PR fixes [IPCT1-340] at https://impactmarket.atlassian.net/browse/IPCT1-340

# Description

This PR changes search behaviour on currency search bar. Instead of relying on local state, the data is read from the input event instead and compares against currency name only, instead of currency symbol and native symbol. 

### Type of change

- Bug fix (fixes an issue)

# How Has This Been Tested?

- [ ] Manually
  - [x] [BLU Advance L5](https://www.amazon.com/Advance-A390L-Unlocked-Phone-Camera/dp/B07Z6Q9NCZ/)
  - [x] Redmi 5 plus Xiaomi
- [ ] Automated

# Screenshots/Videos
![5806](https://user-images.githubusercontent.com/44679989/126723497-b246a2b8-2db6-436c-ac14-b27d478b3c06.jpg)

