### PR TITLE
Add setTimeout on splashScreen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -604,7 +604,11 @@ class App extends React.Component<any, IAppState> {
             await this._checkAcceptanceOfRules();
             this.setState({ isAppReady: true });
             // just at the end, so when we hide, app is ready!
-            SplashScreen.hideAsync();
+            // hack found on https://stackoverflow.com/questions/64780275/at-using-expo-after-splash-screen-blinkflash-with-white-screen
+            // to allow app finish load all resources before hide splash screen
+            setTimeout(() => {
+                SplashScreen.hideAsync();
+            }, 300);
         } catch (e) {
             Sentry.Native.captureException(e);
             return (


### PR DESCRIPTION
This PR fixes [IPCT1-154] at https://impactmarket.atlassian.net/browse/IPCT1-154

# Description

Add a hack found on https://stackoverflow.com/questions/64780275/at-using-expo-after-splash-screen-blinkflash-with-white-screen which allows app finish loads all assets (ie. fonts) before hiding splash screen.

### Type of change

- Bug fix (fixes an issue)

# How Has This Been Tested?

- [ ] Manually
  - [x] [BLU Advance L5](https://www.amazon.com/Advance-A390L-Unlocked-Phone-Camera/dp/B07Z6Q9NCZ/)
  - [x] Other Redmi 5 Plus Xiaomi
- [ ] Automated

# Screenshots/Videos

https://user-images.githubusercontent.com/44679989/126865729-2385856e-266c-476c-8a61-37a29e3cb599.MP4

