### PR TITLE
add plataform visual dependency to FlashMessage

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -39,7 +39,14 @@ import rootSagas from 'helpers/redux/sagas';
 import { isReadyRef, navigationRef } from 'helpers/rootNavigation';
 import moment from 'moment';
 import React from 'react';
-import { Image, View, LogBox, StatusBar, Dimensions } from 'react-native';
+import {
+    Image,
+    View,
+    LogBox,
+    StatusBar,
+    Dimensions,
+    Platform,
+} from 'react-native';
 import FlashMessage from 'react-native-flash-message';
 import {
     DefaultTheme,
@@ -453,7 +460,18 @@ class App extends React.Component<any, IAppState> {
                         backgroundColor="rgba(0, 0, 0, 0.2)"
                         translucent
                     />
-                    <FlashMessage position="top" />
+                    <FlashMessage
+                        position={
+                            Platform.OS === 'ios'
+                                ? 'top'
+                                : {
+                                      top: StatusBar.currentHeight,
+                                      left: 0,
+                                      right: 0,
+                                  }
+                        }
+                        floating={Platform.OS !== 'ios'}
+                    />
                     {config.testnet && testnetWarningView}
                     <NavigationContainer
                         theme={navigationTheme}

--- a/App.tsx
+++ b/App.tsx
@@ -461,16 +461,12 @@ class App extends React.Component<any, IAppState> {
                         translucent
                     />
                     <FlashMessage
-                        position={
-                            Platform.OS === 'ios'
-                                ? 'top'
-                                : {
-                                      top: StatusBar.currentHeight,
-                                      left: 0,
-                                      right: 0,
-                                  }
-                        }
-                        floating={Platform.OS !== 'ios'}
+                        position={{
+                            top: StatusBar.currentHeight,
+                            left: 0,
+                            right: 0,
+                        }}
+                        floating
                     />
                     {config.testnet && testnetWarningView}
                     <NavigationContainer

--- a/src/helpers/redux/sagas/offline.ts
+++ b/src/helpers/redux/sagas/offline.ts
@@ -23,6 +23,13 @@ export function* startWatchingNetworkConnectivity(): any {
                 showMessage({
                     message: i18n.t('sagas.messages.yourNetworkisWeak'),
                     type: 'warning',
+                    backgroundColor: '#FE9A22',
+                    style: {
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                    },
+                    textStyle: { textAlign: 'center' },
                 });
             } else if (
                 // in order to check the "strength" of wifi network we check if the connection is a 4g generation.
@@ -32,6 +39,13 @@ export function* startWatchingNetworkConnectivity(): any {
                 showMessage({
                     message: i18n.t('sagas.messages.yourNetworkisWeak'),
                     type: 'warning',
+                    backgroundColor: '#FE9A22',
+                    style: {
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                    },
+                    textStyle: { textAlign: 'center' },
                 });
             }
 
@@ -40,12 +54,25 @@ export function* startWatchingNetworkConnectivity(): any {
                 showMessage({
                     message: i18n.t('sagas.messages.yourNetworkisOnline'),
                     type: 'success',
+                    backgroundColor: '#2DCE89',
+                    style: {
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                    },
+                    textStyle: { textAlign: 'center' },
                 });
             } else {
                 yield put({ type: OFFLINE });
                 showMessage({
                     message: i18n.t('sagas.messages.yourNetworkisOffline'),
                     type: 'danger',
+                    style: {
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                    },
+                    textStyle: { textAlign: 'center' },
                     autoHide: !netStatus.isConnected,
                 });
             }


### PR DESCRIPTION
This PR fixes [IPCT1-357] at https://impactmarket.atlassian.net/browse/IPCT1-357

# Description
This PR implements a platform awareness on FlashMessage to avoid toast be partially hidden by StatusBar. 

### Type of change

- Bug fix (fixes an issue)

# How Has This Been Tested?
- [x] Manually
  - [x] [BLU Advance L5](https://www.amazon.com/Advance-A390L-Unlocked-Phone-Camera/dp/B07Z6Q9NCZ/)
  - [ ] [SLIDE SP4514](https://www.amazon.com/dp/B06ZZ4KZF9?psc=1&ref=ppx_yo2_dt_b_product_details)
  - [ ] [Asus ZenFone 3 Max](https://www.gsmarena.com/asus_zenfone_3_max_zc520tl-8207.php)
  - [ ] [iPhone 6](https://www.gsmarena.com/apple_iphone_6-6378.php)
  - [x] [iPhone 11](https://www.gsmarena.com/apple_iphone_11-9848.php)
  - [x] Other [XIAOMI REDMI 5 Plus](https://www.gsmarena.com/xiaomi_redmi_5_plus_(redmi_note_5)-8959.php)
- [ ] Automated

# Screenshots/Videos
![WhatsApp Image 2021-08-04 at 20 25 55](https://user-images.githubusercontent.com/44679989/128242752-37e1b915-dbc4-46c6-821f-c3ebd75fa752.jpeg)


