### PR TITLE
remove donate buttons in ios

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
         "slug": "impact-market",
         "privacy": "public",
         "platforms": ["ios", "android"],
-        "version": "1.1.11",
+        "version": "1.1.12",
         "orientation": "portrait",
         "icon": "./src/assets/images/logo/android.png",
         "scheme": "impactmarket",
@@ -27,7 +27,7 @@
             "icon": "./src/assets/images/logo/ios.png",
             "googleServicesFile": "./src/assets/firebase/GoogleService-Info.plist",
             "bundleIdentifier": "com.impactmarket.mobile",
-            "buildNumber": "1.1.11",
+            "buildNumber": "1.1.12",
             "supportsTablet": true
         },
         "android": {
@@ -35,7 +35,7 @@
             "icon": "./src/assets/images/logo/android.png",
             "googleServicesFile": "./src/assets/firebase/google-services.json",
             "package": "com.impactmarket.mobile",
-            "versionCode": 81,
+            "versionCode": 82,
             "adaptiveIcon": {
                 "backgroundImage": "./src/assets/images/logo/android.png",
                 "backgroundColor": "#2362FB"

--- a/src/views/community/details/index.tsx
+++ b/src/views/community/details/index.tsx
@@ -7,7 +7,8 @@ import Card from 'components/core/Card';
 import BackSvg from 'components/svg/header/BackSvg';
 import FaqSvg from 'components/svg/header/FaqSvg';
 import * as shape from 'd3-shape';
-import * as Clipboard from 'expo-clipboard';
+import Clipboard from 'expo-clipboard';
+import * as Device from 'expo-device';
 import * as WebBrowser from 'expo-web-browser';
 import { modalDonateAction } from 'helpers/constants';
 import { amountToCurrency, humanifyCurrencyAmount } from 'helpers/currency';
@@ -325,7 +326,9 @@ export default function CommunityDetailsScreen(props: ICommunityDetailsScreen) {
                     </View>
                 </BaseCommunity>
             </ScrollView>
-            <Donate community={community} />
+            {Device.brand.toLowerCase() !== 'apple' && (
+                <Donate community={community} />
+            )}
         </>
     );
 }

--- a/src/views/stories/Carousel.tsx
+++ b/src/views/stories/Carousel.tsx
@@ -3,6 +3,7 @@ import i18n from 'assets/i18n';
 import BottomPopup from 'components/core/BottomPopup';
 import Button from 'components/core/Button';
 import StoryLoveSvg from 'components/svg/StoryLoveSvg';
+import * as Device from 'expo-device';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Screens } from 'helpers/constants';
 import { ICommunityStories, ICommunityStory } from 'helpers/types/endpoints';
@@ -282,24 +283,28 @@ function Carousel(props: {
                             {stories[index].loves} Loves
                         </Text>
                     </Pressable>
-                    {communityStories?.id !== -1 && (
-                        <Button
-                            modeType="green"
-                            bold
-                            style={{
-                                marginRight: 22,
-                                width: 128,
-                            }}
-                            onPress={() =>
-                                navigation.navigate(Screens.CommunityDetails, {
-                                    communityId: communityStories?.id,
-                                    openDonate: true,
-                                })
-                            }
-                        >
-                            {i18n.t('donate')}
-                        </Button>
-                    )}
+                    {communityStories?.id !== -1 &&
+                        Device.brand.toLowerCase() !== 'apple' && (
+                            <Button
+                                modeType="green"
+                                bold
+                                style={{
+                                    marginRight: 22,
+                                    width: 128,
+                                }}
+                                onPress={() =>
+                                    navigation.navigate(
+                                        Screens.CommunityDetails,
+                                        {
+                                            communityId: communityStories?.id,
+                                            openDonate: true,
+                                        }
+                                    )
+                                }
+                            >
+                                {i18n.t('donate')}
+                            </Button>
+                        )}
                 </View>
                 <View style={{ flexDirection: 'row' }}>
                     {Array(stories.length)


### PR DESCRIPTION
# Description
Donate buttons have been remove from iOS. This is a short-term solution to avoid app store refusing new versions again.