### PR TITLE
add platform awareness on toast

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -39,7 +39,14 @@ import rootSagas from 'helpers/redux/sagas';
 import { isReadyRef, navigationRef } from 'helpers/rootNavigation';
 import moment from 'moment';
 import React from 'react';
-import { Image, View, LogBox, StatusBar, Dimensions } from 'react-native';
+import {
+    Image,
+    View,
+    LogBox,
+    StatusBar,
+    Dimensions,
+    Platform,
+} from 'react-native';
 import FlashMessage from 'react-native-flash-message';
 import {
     DefaultTheme,
@@ -451,7 +458,10 @@ class App extends React.Component<any, IAppState> {
                     />
                     <FlashMessage
                         position={{
-                            top: StatusBar.currentHeight,
+                            top:
+                                Platform.OS === 'android'
+                                    ? StatusBar.currentHeight
+                                    : 50,
                             left: 0,
                             right: 0,
                         }}


### PR DESCRIPTION
This PR fixes [IPCT1-423] at https://impactmarket.atlassian.net/browse/IPCT1-423

# Description
This PR fixes padding awareness on iPhone for offline toasts.

### Type of change
- Bug fix (fixes an issue)

# How Has This Been Tested?
- [x] Manually
  - [x] [BLU Advance L5](https://www.amazon.com/Advance-A390L-Unlocked-Phone-Camera/dp/B07Z6Q9NCZ/)
  - [ ] [SLIDE SP4514](https://www.amazon.com/dp/B06ZZ4KZF9?psc=1&ref=ppx_yo2_dt_b_product_details)
  - [ ] [Asus ZenFone 3 Max](https://www.gsmarena.com/asus_zenfone_3_max_zc520tl-8207.php)
  - [ ] [iPhone 6](https://www.gsmarena.com/apple_iphone_6-6378.php)
  - [x] [iPhone 11] (https://www.gsmarena.com/apple_iphone_11-9848.php)
- [ ] Automated

# Screenshots/Videos
![IMG_1690](https://user-images.githubusercontent.com/44679989/132710168-9ae8cd02-7f3e-4a0d-98aa-e24c40e39c5e.PNG)
![IMG_40A0D5BE7206-1](https://user-images.githubusercontent.com/44679989/132710180-20edfb32-4140-4f13-85c5-00822bc4c615.jpeg)

